### PR TITLE
Fix URL to github in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/most-inesctec/I2BplusTree.git"
+    "url": "git+https://github.com/most-inesctec/I2Bplus-tree.git"
   },
   "keywords": [
     "I2B+tree",


### PR DESCRIPTION
Current URL leads to 404:
![image](https://user-images.githubusercontent.com/8374473/132327964-9648c397-a089-4984-bb87-5f2b1ed0ce71.png)
![image](https://user-images.githubusercontent.com/8374473/132329085-6d1e3f69-059b-4489-bf2b-86034d7a2761.png)
